### PR TITLE
feat: Add Support for Market Updates

### DIFF
--- a/contracts/src/events.cairo
+++ b/contracts/src/events.cairo
@@ -68,6 +68,19 @@ pub struct BetPlaced {
     pub amount: u256,
 }
 
+#[derive(Drop, starknet::Event)]
+pub struct MarketDurationExtended {
+    pub market_id: u256,
+    pub updated_by: ContractAddress,
+    pub new_end_time: u64,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct MarketDetailsModified {
+    pub market_id: u256,
+    pub updated_by: ContractAddress,
+}
+
 // ================ Main Event Enum ================
 
 #[derive(Drop, starknet::Event)]
@@ -81,4 +94,6 @@ pub enum Event {
     FeesCollected: FeesCollected,
     WinningsCollected: WinningsCollected,
     BetPlaced: BetPlaced,
+    MarketDurationExtended: MarketDurationExtended,
+    MarketDetailsModified: MarketDetailsModified,
 }

--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -139,4 +139,12 @@ pub trait IPredictionHub<TContractState> {
     fn remove_all_predictions(ref self: TContractState);
     /// Upgrades the contract implementation (admin only)
     fn upgrade(ref self: TContractState, impl_hash: ClassHash);
+
+    // ================ Market Update Functions ================
+
+    /// Extends a market's duration by updating its end_time (moderator/admin only)
+    fn extend_market_duration(ref self: TContractState, market_id: u256, new_end_time: u64);
+
+    /// Modifies a market's description (moderator/admin only)
+    fn modify_market_details(ref self: TContractState, market_id: u256, new_description: ByteArray);
 }

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -5,7 +5,7 @@ use pragma_lib::types::DataType;
 use stakcast::admin_interface::IAdditionalAdmin;
 use stakcast::events::{
     BetPlaced, EmergencyPaused, Event, FeesCollected, MarketCreated, MarketResolved, ModeratorAdded,
-    ModeratorRemoved, WagerPlaced, WinningsCollected,
+    ModeratorRemoved, WagerPlaced, WinningsCollected, MarketDurationExtended, MarketDetailsModified,
 };
 use stakcast::interface::IPredictionHub;
 use stakcast::types::{BetActivity, Choice, MarketStatus, Outcome, PredictionMarket, UserStake};
@@ -1068,6 +1068,58 @@ pub mod PredictionHub {
         }
         // ================ Multi-Token Support Functions ================
 
+
+        // ================ Market Update Functions ================
+
+        fn extend_market_duration(ref self: ContractState, market_id: u256, new_end_time: u64) {
+            // Check authorization - only moderators or admin can update markets
+            self.assert_only_moderator_or_admin();
+
+            // Ensure the market exists
+            self.assert_market_exists(market_id);
+
+            // Validate the new end time
+            self.assert_valid_market_timing(new_end_time);
+
+            // Read the current market
+            let mut market = self.all_predictions.entry(market_id).read();
+
+            // Update the end time
+            market.end_time = new_end_time;
+
+            // Write the updated market back to storage
+            self.all_predictions.entry(market_id).write(market);
+
+            // Emit event
+            self.emit(MarketDurationExtended { 
+                market_id, 
+                updated_by: get_caller_address(), 
+                new_end_time 
+            });
+        }
+
+        fn modify_market_details(ref self: ContractState, market_id: u256, new_description: ByteArray) {
+            // Check authorization - only moderators or admin can update markets
+            self.assert_only_moderator_or_admin();
+
+            // Ensure the market exists
+            self.assert_market_exists(market_id);
+
+            // Read the current market
+            let mut market = self.all_predictions.entry(market_id).read();
+
+            // Update the description
+            market.description = new_description;
+
+            // Write the updated market back to storage
+            self.all_predictions.entry(market_id).write(market);
+
+            // Emit event
+            self.emit(MarketDetailsModified { 
+                market_id, 
+                updated_by: get_caller_address() 
+            });
+        }
     }
 
 


### PR DESCRIPTION
Implements two new functions to support market updates:

- `extend_market_duration()` - Allows authorized users to extend market end times
- `modify_market_details()` - Allows authorized users to update market descriptions

Both functions include proper authorization checks, validation, and event emission.

Resolves #3

🤖 Generated with [Claude Code](https://claude.ai/code)